### PR TITLE
Add workflow to lock PRs

### DIFF
--- a/.github/workflows/lockdown.yml
+++ b/.github/workflows/lockdown.yml
@@ -1,0 +1,22 @@
+name: 'Repo Lockdown'
+
+on:
+  pull_request_target:
+    types: opened
+  schedule:
+    - cron: '0 * * * *'
+
+permissions:
+  pull-requests: write
+
+jobs:
+  action:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dessant/repo-lockdown@v2
+        with:
+          github-token: ${{ github.token }}
+          process-only: 'prs'
+          pr-comment: >
+            This repository does not accept pull requests,
+            see the README for details.


### PR DESCRIPTION
This will add a workflow that automatically closes all PRs to this repo whenever they're opened and instructs the person who opened the PR to read the README.

References:
https://github.com/dessant/repo-lockdown
