### PR TITLE
Meron/exclude pinned PRs

### DIFF
--- a/.github/workflows/lockdown.yml
+++ b/.github/workflows/lockdown.yml
@@ -20,3 +20,4 @@ jobs:
           pr-comment: >
             This repository does not accept pull requests,
             see the README for details.
+          exclude-pr-labels: 'pinned'


### PR DESCRIPTION
This will prevent PRs with the pinned label from triggering the repo lockdown github action.